### PR TITLE
Fix switch statement syntax

### DIFF
--- a/www/app/Http/Controller/Admin/Home/Dashboard.php
+++ b/www/app/Http/Controller/Admin/Home/Dashboard.php
@@ -56,25 +56,25 @@ class  Dashboard extends Page {
             case 'routeInvalid':
                 return Alert::getError('Erro :(','Não é possivel acessar essa rota!');
                 break;
-            case 'companyInvalid';
+            case 'companyInvalid':
                 return Alert::getError('Erro :(','Não é possivel acessar essa rota da empresa!');
                 break;
-            case 'cepInvalid';
+            case 'cepInvalid':
                 return Alert::getError('Erro :(','Não é possivel acessar essa rota CEP!');
                 break;
-            case 'clientInvalid';
+            case 'clientInvalid':
                 return Alert::getError('Erro :(','Não é possivel acessar essa rota CLIENTE!');
                 break;
-            case 'solarInvalid';
+            case 'solarInvalid':
                 return Alert::getError('Erro :(','Não é possivel acessar essa rota SOLAR!');
                 break;
-            case 'callInvalid';
+            case 'callInvalid':
                 return Alert::getError('Erro :(','Não é possivel acessar essa rota de CHAMADOS!');
                 break;
-            case 'listInvalid';
+            case 'listInvalid':
                 return Alert::getError('Erro :(','Não é possivel acessar essa lista mailing');
                 break;
-            case 'mailingInvalid';
+            case 'mailingInvalid':
                 return Alert::getError('Erro :(','Não é possivel acessar esse mailing');
                 break;
         }

--- a/www/app/Http/Middleware/RequireNivelSellerList.php
+++ b/www/app/Http/Middleware/RequireNivelSellerList.php
@@ -27,13 +27,13 @@ class RequireNivelSellerList {
         //CONDIÇÃO PARA LISTAS DESKTOP
         if ($mailing === 'desktop'){
             switch ($arrayUri[2]) {
-                case 'get';
+                case 'get':
                 $mailing = 'desktop_get';
                 break;
-                case 'sis';
+                case 'sis':
                 $mailing = 'desktop_sis';
                 break;
-                case 'netbarretos';
+                case 'netbarretos':
                 $mailing = 'desktop_netbarretos';
                 break;
             }

--- a/www/app/Http/Response.php
+++ b/www/app/Http/Response.php
@@ -78,13 +78,13 @@ class Response{
 
         //IMPRIME O CONTEUDO
         switch ($this->contentType) {
-            case 'text/html';
+            case 'text/html':
                 echo $this->content;
             exit;
-            case 'text/csv';
+            case 'text/csv':
                 echo $this->content;
             exit;
-            case 'application/json';
+            case 'application/json':
                 echo json_encode($this->content, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
                 exit;
         }


### PR DESCRIPTION
## Summary
- correct invalid switch cases in Dashboard controller, Response handler, and RequireNivelSellerList middleware

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847905d8134832da85275dfc794ad40